### PR TITLE
Add shfmt to flake and justfile

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -325,6 +325,7 @@
           hooks = {
             ruff.enable = true;
             shellcheck.enable = true;
+            shfmt.enable = true;
             markdownlint.enable = true;
             alejandra.enable = true;
             editorconfig-checker.enable = true;

--- a/justfile
+++ b/justfile
@@ -36,5 +36,5 @@ fix:
     ruff format .
     shopt -s globstar nullglob
     shellcheck -f diff **/*.sh | patch -p0 || true
-    # shfmt -w -i 4 -bn -sr **/*.sh
+    shfmt -w -i 4 -bn -sr **/*.sh
 


### PR DESCRIPTION
## Summary
- enable `shfmt` as a pre-commit hook in `flake.nix`
- run `shfmt` in the `fix` recipe of the `justfile`

## Testing
- `nix flake check` *(fails: unable to fetch from cache)*