### PR TITLE
Update keymaps and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,14 @@ It should also be a reasonable replacement for a well configured vs code / curso
 - `[t` `]t` — previous/next tab
 - `<C-Up>` `<C-Down>` `<C-Left>` `<C-Right>` — resize windows
 - `<Leader>w=` — equalize window sizes
-- `[b` `]b` — previous/next buffer
+- `[b` `]b` or `<A-Left>` `<A-Right>` — previous/next buffer
 - `<C-t>` — new tab
-- `<C-n>` — clear search highlight
+- `<C-n>` — open notes
+- `<C-f>` — git finder
+- `<C-b>` — buffer finder
+- `<C-d>` — close buffer
+- `<C-x>` — diagnostics list
+- `<C-a>` — toggle Avante
 - `<C-s>` — save file
 - `<Leader>qb` `<Leader>qB` `<Leader>qw` `<Leader>qt` `<Leader>qa` — close buffers/windows/tabs
 - `<` / `>` in visual mode — keep selection while indenting

--- a/lua/nvim/keymaps/keymaps.lua
+++ b/lua/nvim/keymaps/keymaps.lua
@@ -46,12 +46,20 @@ map('n', '<Leader>w=', '<cmd>tabdo wincmd =<CR>', { desc = 'Window auto resize' 
 -- Navigate buffers
 map('n', '[b', '<cmd>bprevious<CR>', { desc = 'Previous buffer' })
 map('n', ']b', '<cmd>bnext<CR>', { desc = 'Next buffer' })
+map('n', '<M-Left>', '<cmd>bprevious<CR>', { desc = 'Previous buffer' })
+map('n', '<M-Right>', '<cmd>bnext<CR>', { desc = 'Next buffer' })
 
 -- Tab management
 map('n', '<C-t>', '<cmd>tabnew<CR>', { desc = 'New tab' })
 
 -- Turn off search highlight
-map('n', '<C-n>', '<cmd>nohl<CR>', { desc = 'Clear search highlight' })
+-- Notes and utilities
+map('n', '<C-n>', '<cmd>ObsidianQuickSwitch<CR>', { desc = 'Open notes' })
+map('n', '<C-f>', '<cmd>lua Snacks.picker.git_files({untracked=true})<cr>', { desc = 'Git finder' })
+map('n', '<C-b>', '<cmd>lua Snacks.picker.buffers()<cr>', { desc = 'Buffer finder' })
+map('n', '<C-d>', "<cmd>lua require('snacks').bufdelete()<CR>", { desc = 'Close buffer' })
+map('n', '<C-x>', '<cmd>Trouble diagnostics toggle focus=true<cr>', { desc = 'Diagnostics list' })
+map('n', '<C-a>', '<cmd>AvanteToggle<cr>', { desc = 'Toggle Avante' })
 
 -- Save files
 map('n', '<C-s>', '<cmd>w<CR>', { desc = 'Save file' })


### PR DESCRIPTION
## Summary
- map Alt+Left/Right to cycle buffers
- add control shortcuts for finder, notes, diagnostics and Avante toggle
- document new shortcuts in README

## Testing
- `nix flake check` *(fails: Could not connect to server)*