### PR TITLE
Add logging for error notifications

### DIFF
--- a/lua/nvim/ui/notifications.lua
+++ b/lua/nvim/ui/notifications.lua
@@ -3,10 +3,39 @@ require('lze').load {
     'nvim-notify',
     -- event = { 'DeferredUIEnter' },
     after = function(_)
-      require('notify').setup {
+      local notify = require 'notify'
+      notify.setup {
         level = 'info',
         background_color = '#191724',
       }
+
+      local default_timeout = notify._config.timeout or 5000
+      local original_notify = vim.notify
+
+      local function map_level(l)
+        if type(l) == 'string' then
+          return vim.log.levels[string.upper(l)]
+        end
+        return l
+      end
+
+      vim.notify = function(msg, level, opts)
+        opts = opts or {}
+        if map_level(level) == vim.log.levels.ERROR then
+          opts.timeout = (opts.timeout or default_timeout) * 2
+
+          local dir = vim.fn.expand '~/.config/state/nvim'
+          vim.fn.mkdir(dir, 'p')
+          local file = dir .. '/errors.log'
+          local f = io.open(file, 'a')
+          if f then
+            f:write(os.date '%Y-%m-%d %H:%M:%S' .. ' ' .. msg .. '\n')
+            f:close()
+          end
+        end
+
+        return original_notify(msg, level, opts)
+      end
     end,
   },
   {


### PR DESCRIPTION
## Summary
- log error notifications to `~/.config/state/nvim/errors.log`
- show error notifications twice as long

## Testing
- `pre-commit` *(fails: `pre-commit: command not found`)*
